### PR TITLE
Add PZ Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated collection of the best stuff from the Wails ecosystem and community.
 - [grpcmd-gui](https://grpc.md/gui) - A modern cross-platform desktop app and API client for gRPC development and testing.
 - [go-stock](https://github.com/ArvinLovegood/go-stock) - A chinese stock data viewer build by Wails with NavieUI.
 - [serial reader window](https://github.com/nnttoo/serial_reader/) open-source application read data from serial ports (COM) on Windows
+- [PZ Admin](https://github.com/beyenilmez/pz-admin) - A desktop application for managing Project Zomboid servers with RCON.
 
 ### Closed Source
 


### PR DESCRIPTION
PZ Admin is a desktop application for managing Project Zomboid servers via the RCON protocol, providing tools for server and player management. It supports Windows and Linux, offering features like remote console access, player moderation, and server configuration.
Repository: https://github.com/beyenilmez/pz-admin
Website: https://beyenilmez.github.io/pz-admin/
![image](https://github.com/user-attachments/assets/02c44efb-e130-4ac4-9ba9-0d5a416a519f)
